### PR TITLE
2.5.6: Fix  issue #367 "unwanted '.html' on the end"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,11 @@
 ## change log ##
 
 * 2015-11-18: ont\&orrportal 2.5.6
+  - Fix \#367 "unwanted '.html' on the end"
+    ...ont.util.Util.getLink was not considering that the value should be ont-resolvable to append the .html, only that 
+    it was an MmiUri (which a URI like http://vocab.nerc.ac.uk/collection/P07/current/M4KOX5A0/ satisfies. 
+    
+* 2015-11-18: ont\&orrportal 2.5.6
   - Fix \#311 "strange case when mapping to http://mmisw.org/ont/cf" 
   	- disable loading of imported ontologies in two places
 		- OntClientUtil.retrieveModel

--- a/org.mmisw.ont/src/org/mmisw/ont/util/Util.java
+++ b/org.mmisw.ont/src/org/mmisw/ont/util/Util.java
@@ -335,7 +335,7 @@ public class Util {
 
 	/**
 	 * Returns a string that can be used as a link.
-	 * If it is an MmiUri, a ".html" is appended;
+	 * If the value is ont-resolvable and an MmiUri, a ".html" is appended;
 	 * otherwise, if it is a valid URL, it is returned as it is;
 	 * otherwise, null is returned.
 	 *
@@ -343,13 +343,16 @@ public class Util {
 	 * @return the string that can be used as a link as stated above; null if value is not a URL.
 	 */
 	public static String getLink(String value) {
-		// try mmiUri:
-		try {
-			MmiUri mmiUri = new MmiUri(value);
-			return mmiUri.getTermUri() + ".html";
-		}
-		catch (URISyntaxException e1) {
-			// ignore. Try URL below.
+		if (OntUtil.isOntResolvableUri(value)) {
+			// try mmiUri:
+			try {
+				MmiUri mmiUri = new MmiUri(value);
+				return mmiUri.getTermUri() + ".html";
+			}
+			catch (URISyntaxException e1) {
+				// ignore. Try URL below.
+			}
+
 		}
 
 		// try regular URL:


### PR DESCRIPTION
 ...ont.util.Util.getLink was not considering that the value should be ont-resolvable to append the .html, only that  it was an MmiUri (which a URI like http://vocab.nerc.ac.uk/collection/P07/current/M4KOX5A0/ satisfies.